### PR TITLE
Fix not showing withBoardedge.PNG (Line 519)

### DIFF
--- a/kicad/tutorial.md
+++ b/kicad/tutorial.md
@@ -516,7 +516,7 @@ Remember that one click adds a segment, two clicks or escape ends the tool.
 
 The silkscreen of parts normally indicates their extent. Because there is no harm in letting the USB connector extend beyond the edge of this board I have defined the board extents to cut part of the silk screen off, this will make the board smaller and save money:
 
-![Layout](withBoardEdge.PNG)
+![Layout](withBoardedge.PNG)
  
 Now we may route the board.
 


### PR DESCRIPTION
withBoardEdge.PNG links to withBoardedge.PNG, causing it not to be displayed. (Line 519)
Changed link to withBoardedge.PNG

Let me know if it's ok to suggest updates for KiCAD 5.
Happy 2019!